### PR TITLE
Fix search/page persistance, add sorting options for university

### DIFF
--- a/Webserver/Enums/Enums.cs
+++ b/Webserver/Enums/Enums.cs
@@ -1,0 +1,10 @@
+﻿namespace Webserver.Enums
+{
+    public enum UniversitySortOrders
+    {
+        NAME_ASC,
+        NAME_DESC,
+        CITY_ASC,
+        CITY_DESC
+    }
+}

--- a/Webserver/Models/ViewModels/Pagination/PagerViewModel.cs
+++ b/Webserver/Models/ViewModels/Pagination/PagerViewModel.cs
@@ -1,11 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Webserver.Models.ViewModels.Pagination
 {
-    public class PagerViewModel<T> where T : class
+    public class PagerViewModel<T, E> where T : class where E : struct, IConvertible
     {
         public IEnumerable<T> Items { get; set; }
 
         public Pager Pager { get; set; }
+
+        public E SortOrder { get; set; }
     }
 }

--- a/Webserver/Views/Universities/Add.cshtml
+++ b/Webserver/Views/Universities/Add.cshtml
@@ -38,7 +38,7 @@
 }
 
 <div>
-    @Html.ActionLink("Back to List", "Index")
+    @Html.ActionLink("Back to List", "Index", new { navigation = true })
 </div>
 
 @section Scripts {

--- a/Webserver/Views/Universities/Details.cshtml
+++ b/Webserver/Views/Universities/Details.cshtml
@@ -28,7 +28,7 @@
 </div>
 
 <p>
-    @Html.ActionLink("Back to List", "Index")
+    @Html.ActionLink("Back to List", "Index", new { navigation = true })
 </p>
 <p>
     @Html.ActionLink("See Faculties", "Index", "Faculties", new { universityId = Model.Id }, null)

--- a/Webserver/Views/Universities/Index.cshtml
+++ b/Webserver/Views/Universities/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@model Webserver.Models.ViewModels.Pagination.PagerViewModel<Models.University>
+﻿@model Webserver.Models.ViewModels.Pagination.PagerViewModel<Models.University, Webserver.Enums.UniversitySortOrders>
 
 @{
     ViewBag.Title = "Universities";
@@ -9,7 +9,7 @@
 @using (Html.BeginForm("Index", "Universities", FormMethod.Get))
 {
     <ul class="nav navbar-nav">
-        <li>@Html.TextBox("searchCriteria", "")</li>
+        <li>@Html.TextBox("searchCriteria", Session["UniversitySearchCriteria"]?.ToString())</li>
         <li><input type="submit" value="Search" /></li>
     </ul>
 }
@@ -18,10 +18,28 @@
     <table class="table">
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Items.LastOrDefault().Name)
+                @if (Model.SortOrder == Webserver.Enums.UniversitySortOrders.NAME_ASC)
+                {
+                    @Html.ActionLink("Name", "Index",
+                        new { page = Model.Pager.CurrentPage, searchCriteria = ViewBag.SearchCriteria, sortOrder = Webserver.Enums.UniversitySortOrders.NAME_DESC })
+                }
+                else
+                {
+                    @Html.ActionLink("Name", "Index",
+                        new { page = Model.Pager.CurrentPage, searchCriteria = ViewBag.SearchCriteria, sortOrder = Webserver.Enums.UniversitySortOrders.NAME_ASC })
+                }
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Items.LastOrDefault().City)
+                @if (Model.SortOrder == Webserver.Enums.UniversitySortOrders.CITY_ASC)
+                {
+                    @Html.ActionLink("City", "Index",
+                        new { page = Model.Pager.CurrentPage, searchCriteria = ViewBag.SearchCriteria, sortOrder = Webserver.Enums.UniversitySortOrders.CITY_DESC })
+                }
+                else
+                {
+                    @Html.ActionLink("City", "Index",
+                        new { page = Model.Pager.CurrentPage, searchCriteria = ViewBag.SearchCriteria, sortOrder = Webserver.Enums.UniversitySortOrders.CITY_ASC })
+                }
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.Items.LastOrDefault().Description)

--- a/Webserver/Webserver.csproj
+++ b/Webserver/Webserver.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="Enums\Enums.cs" />
     <Compile Include="Migrations\201911232102516_InitialCreate.cs" />
     <Compile Include="Migrations\201911232102516_InitialCreate.Designer.cs">
       <DependentUpon>201911232102516_InitialCreate.cs</DependentUpon>


### PR DESCRIPTION
* Search criteria and current page of Universities view is now stored in session data, meaning it persists between navigation (from details page for example)
* Added sorting options for Universities view. They also persist just like mentioned above

Elegant solution suggestions and/or refactors are highly appreciated!